### PR TITLE
Fix fov overflow

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.22
-loader_version=0.12.12
+minecraft_version=1.20
+yarn_mappings=1.20+build.1
+loader_version=0.14.21
 # Mod Properties
-mod_version=1.1.0-1.18.1
+mod_version=1.1.0-1.20
 maven_group=daniel
 archives_base_name=keybinds_plus
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.46.1+1.18
+fabric_version=0.83.0+1.20

--- a/src/main/java/daniel/keybinds_plus/client/KeybindsPlus.java
+++ b/src/main/java/daniel/keybinds_plus/client/KeybindsPlus.java
@@ -15,8 +15,8 @@ import net.minecraft.client.option.Perspective;
 import net.minecraft.client.render.entity.PlayerModelPart;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.sound.SoundCategory;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
+import net.minecraft.text.Text;
 import net.minecraft.text.TextColor;
 import net.minecraft.util.Formatting;
 import org.lwjgl.glfw.GLFW;
@@ -55,7 +55,7 @@ public class KeybindsPlus implements ClientModInitializer {
             //this is a bit cringe
             if (((SkinActions)actionTypes[4]).isAnySet() && client != null) {
                 client.player.sendMessage(
-                        new LiteralText("WARNING: Using skin toggling settings may trigger anti-cheat plugins!")
+                        Text.literal("WARNING: Using skin toggling settings may trigger anti-cheat plugins!")
                                 .setStyle(Style.EMPTY.withColor(TextColor.fromFormatting(Formatting.RED))),
                         false
                 );

--- a/src/main/java/daniel/keybinds_plus/client/actions/AudioActions.java
+++ b/src/main/java/daniel/keybinds_plus/client/actions/AudioActions.java
@@ -6,7 +6,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.sound.SoundCategory;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import org.apache.commons.lang3.StringUtils;
 
 public class AudioActions implements ActionType {
@@ -39,8 +39,8 @@ public class AudioActions implements ActionType {
     @Override
     public void execute(MinecraftClient client) {
         while (toggleSubtitlesKeybind.wasPressed()) {
-            client.options.showSubtitles = !client.options.showSubtitles;
-            client.player.sendMessage(new LiteralText("Subtitles " + (client.options.showSubtitles ? "enabled" : "disabled")), true);
+            client.options.getShowSubtitles().setValue(!client.options.getShowSubtitles().getValue());
+            client.player.sendMessage(Text.literal("Subtitles " + (client.options.getShowSubtitles().getValue() ? "enabled" : "disabled")), true);
         }
 
         for (int i = 0; i < soundCategoryKeybinds.length; i++) {
@@ -48,17 +48,17 @@ public class AudioActions implements ActionType {
                 float currentSoundVolume = client.options.getSoundVolume(soundCategories[i]);
 
                 if (currentSoundVolume == 0 && previousVolumes[i] == 0) {
-                    client.options.setSoundVolume(soundCategories[i], 1f);
-                    client.player.sendMessage(new LiteralText(StringUtils.capitalize(soundCategories[i].getName()) + " sound source was resumed"), true);
+                    client.options.getSoundVolumeOption(soundCategories[i]).setValue(1.0);
+                    client.player.sendMessage(Text.literal(StringUtils.capitalize(soundCategories[i].getName()) + " sound source was resumed"), true);
                 }
                 else if (currentSoundVolume > 0) {
                     previousVolumes[i] = currentSoundVolume;
-                    client.options.setSoundVolume(soundCategories[i], 0);
-                    client.player.sendMessage(new LiteralText(StringUtils.capitalize(soundCategories[i].getName()) + " sound source was muted"), true);
+                    client.options.getSoundVolumeOption(soundCategories[i]).setValue(0.0);
+                    client.player.sendMessage(Text.literal(StringUtils.capitalize(soundCategories[i].getName()) + " sound source was muted"), true);
                 }
                 else if (currentSoundVolume == 0 && previousVolumes[i] > 0) {
-                    client.options.setSoundVolume(soundCategories[i], previousVolumes[i]);
-                    client.player.sendMessage(new LiteralText(StringUtils.capitalize(soundCategories[i].getName()) + " sound source was resumed"), true);
+                    client.options.getSoundVolumeOption(soundCategories[i]).setValue((double) previousVolumes[i]);
+                    client.player.sendMessage(Text.literal(StringUtils.capitalize(soundCategories[i].getName()) + " sound source was resumed"), true);
                 }
             }
         }
@@ -68,7 +68,7 @@ public class AudioActions implements ActionType {
             float currentSoundVolume = client.options.getSoundVolume(SoundCategory.WEATHER);
 
             client.options.setSoundVolume(SoundCategory.WEATHER, client.options.getSoundVolume(SoundCategory.WEATHER) == 0 ? 100 : 0);
-            client.player.sendMessage(new LiteralText("Weather sounds were " + (client.options.getSoundVolume(SoundCategory.WEATHER) == 0 ? "muted" : "resumed")), true);
+            client.player.sendMessage(Text.literal("Weather sounds were " + (client.options.getSoundVolume(SoundCategory.WEATHER) == 0 ? "muted" : "resumed")), true);
         }
 
          */

--- a/src/main/java/daniel/keybinds_plus/client/actions/CameraActions.java
+++ b/src/main/java/daniel/keybinds_plus/client/actions/CameraActions.java
@@ -6,7 +6,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.option.Perspective;
 import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 
 public class CameraActions implements ActionType {
     private Perspective lastPerspective = Perspective.FIRST_PERSON;
@@ -72,17 +72,17 @@ public class CameraActions implements ActionType {
     public void execute(MinecraftClient client) {
         while (firstPersonKeybind.wasPressed()) {
             client.options.setPerspective(Perspective.FIRST_PERSON);
-            client.player.sendMessage(new LiteralText("Perspective set to " + client.options.getPerspective().name()), true);
+            client.player.sendMessage(Text.literal("Perspective set to " + client.options.getPerspective().name()), true);
         }
 
         while (thirdPersonKeybind.wasPressed()) {
             client.options.setPerspective(Perspective.THIRD_PERSON_BACK);
-            client.player.sendMessage(new LiteralText("Perspective set to " + client.options.getPerspective().name()), true);
+            client.player.sendMessage(Text.literal("Perspective set to " + client.options.getPerspective().name()), true);
         }
 
         while (thirdPersonFrontKeybind.wasPressed()) {
             client.options.setPerspective(Perspective.THIRD_PERSON_FRONT);
-            client.player.sendMessage(new LiteralText("Perspective set to " + client.options.getPerspective().name()), true);
+            client.player.sendMessage(Text.literal("Perspective set to " + client.options.getPerspective().name()), true);
         }
 
         if (!holdingFirstPerson && !holdingThirdPersonFront && !holdingThirdPerson && tempFirstPersonKeybind.isPressed()) {

--- a/src/main/java/daniel/keybinds_plus/client/actions/ControlsActions.java
+++ b/src/main/java/daniel/keybinds_plus/client/actions/ControlsActions.java
@@ -5,7 +5,7 @@ import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 
 import java.text.DecimalFormat;
 
@@ -44,16 +44,16 @@ public class ControlsActions implements ActionType {
     @Override
     public void execute(MinecraftClient client) {
         while (increaseSensitivity.wasPressed()) {
-            client.options.mouseSensitivity += 0.005;
-            client.player.sendMessage(new LiteralText("Sensitivity was increased to " + sensitivityFormat.format(client.options.mouseSensitivity)), true);
+            client.options.getMouseSensitivity().setValue(client.options.getMouseSensitivity().getValue() + 0.005);
+            client.player.sendMessage(Text.literal("Sensitivity was increased to " + sensitivityFormat.format(client.options.getMouseSensitivity().getValue())), true);
         }
         while (decreaseSensitivity.wasPressed()) {
-            client.options.mouseSensitivity -= 0.005;
-            client.player.sendMessage(new LiteralText("Sensitivity was decreased to " + sensitivityFormat.format(client.options.mouseSensitivity)), true);
+            client.options.getMouseSensitivity().setValue(client.options.getMouseSensitivity().getValue() - 0.005);
+            client.player.sendMessage(Text.literal("Sensitivity was decreased to " + sensitivityFormat.format(client.options.getMouseSensitivity().getValue())), true);
         }
         while (autoJumpKeybind.wasPressed()) {
-            client.options.autoJump = !client.options.autoJump;
-            client.player.sendMessage(new LiteralText("Auto Jump " + (client.options.autoJump ? "enabled" : "disabled")), true);
+            client.options.getAutoJump().setValue(!client.options.getAutoJump().getValue());
+            client.player.sendMessage(Text.literal("Auto Jump " + (client.options.getAutoJump().getValue() ? "enabled" : "disabled")), true);
         }
     }
 }

--- a/src/main/java/daniel/keybinds_plus/client/actions/GraphicsActions.java
+++ b/src/main/java/daniel/keybinds_plus/client/actions/GraphicsActions.java
@@ -4,7 +4,7 @@ import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 
 import java.text.DecimalFormat;
 
@@ -58,30 +58,30 @@ public class GraphicsActions implements ActionType {
     @Override
     public void execute(MinecraftClient client) {
         while (toggleViewBobbing.wasPressed()) {
-            client.options.bobView = !client.options.bobView;
-            client.player.sendMessage(new LiteralText("View Bobbing " + (client.options.bobView ? "enabled" : "disabled")), true);
+            client.options.getBobView().setValue(!client.options.getBobView().getValue());
+            client.player.sendMessage(Text.literal("View Bobbing " + (client.options.getBobView().getValue() ? "enabled" : "disabled")), true);
         }
 
         while (increaseBrightnessKeybind.wasPressed()) {
-            client.options.gamma += 0.1;
-            client.player.sendMessage(new LiteralText("Brightness was increased to " + fovFormat.format(client.options.gamma)), true);
+            client.options.getGamma().setValue(client.options.getGamma().getValue() + 0.1);
+            client.player.sendMessage(Text.literal("Brightness was increased to " + fovFormat.format(client.options.getGamma().getValue())), true);
 
         }
 
         while (decreaseBrightnessKeybind.wasPressed()) {
-            client.options.gamma -= 0.1;
-            client.player.sendMessage(new LiteralText("Brightness was decreased to " + fovFormat.format(client.options.gamma)), true);
+            client.options.getGamma().setValue(client.options.getGamma().getValue() - 0.1);
+            client.player.sendMessage(Text.literal("Brightness was decreased to " + fovFormat.format(client.options.getGamma().getValue())), true);
 
         }
 
         while (increaseFovKeybind.wasPressed()) {
-            client.options.fov += 0.1;
-            client.player.sendMessage(new LiteralText("FOV was increased to " + fovFormat.format(client.options.fov)), true);
+            client.options.getFov().setValue(client.options.getFov().getValue() + 1);
+            client.player.sendMessage(Text.literal("FOV was increased to " + fovFormat.format(client.options.getFov().getValue())), true);
         }
 
         while (decreaseFovKeybind.wasPressed()) {
-            client.options.fov -= 0.1;
-            client.player.sendMessage(new LiteralText("FOV was decreased to " + fovFormat.format(client.options.fov)), true);
+            client.options.getFov().setValue(client.options.getFov().getValue() - 1);
+            client.player.sendMessage(Text.literal("FOV was decreased to " + fovFormat.format(client.options.getFov().getValue())), true);
         }
     }
 }

--- a/src/main/java/daniel/keybinds_plus/client/actions/GraphicsActions.java
+++ b/src/main/java/daniel/keybinds_plus/client/actions/GraphicsActions.java
@@ -74,14 +74,20 @@ public class GraphicsActions implements ActionType {
 
         }
 
-        while (increaseFovKeybind.wasPressed()) {
-            client.options.getFov().setValue(client.options.getFov().getValue() + 1);
-            client.player.sendMessage(Text.literal("FOV was increased to " + fovFormat.format(client.options.getFov().getValue())), true);
-        }
+        while (increaseFovKeybind.wasPressed()) changeFov(client, +1);
+        while (decreaseFovKeybind.wasPressed()) changeFov(client, -1);
+    }
 
-        while (decreaseFovKeybind.wasPressed()) {
-            client.options.getFov().setValue(client.options.getFov().getValue() - 1);
-            client.player.sendMessage(Text.literal("FOV was decreased to " + fovFormat.format(client.options.getFov().getValue())), true);
+    public void changeFov(MinecraftClient client, int delta) {
+        int oldValue = client.options.getFov().getValue();
+        int expectedValue = oldValue + delta;
+        client.options.getFov().setValue(expectedValue);
+        if (expectedValue != client.options.getFov().getValue()) {
+            client.options.getFov().setValue(oldValue);
+        }
+        else {
+            client.player.sendMessage(Text.literal(String.format("FOV was %s to %s",
+                    delta > 0 ? "increased" : "decreased", fovFormat.format(client.options.getFov().getValue()))), true);
         }
     }
 }

--- a/src/main/java/daniel/keybinds_plus/client/actions/SkinActions.java
+++ b/src/main/java/daniel/keybinds_plus/client/actions/SkinActions.java
@@ -6,7 +6,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.render.entity.PlayerModelPart;
 import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import net.minecraft.util.Arm;
 
 public class SkinActions implements ActionType {
@@ -36,9 +36,9 @@ public class SkinActions implements ActionType {
     @Override
     public void execute(MinecraftClient client) {
         while (toggleMainHandKeybind.wasPressed()) {
-            client.options.mainArm = client.options.mainArm == Arm.LEFT ? Arm.RIGHT : Arm.LEFT;
+            client.options.getMainArm().setValue(client.options.getMainArm().getValue() == Arm.LEFT ? Arm.RIGHT : Arm.LEFT);
             client.options.sendClientSettings();
-            client.player.sendMessage(new LiteralText("Main hand set to " + client.options.mainArm.getOptionName().getString()), true);
+            client.player.sendMessage(Text.literal("Main hand set to " + client.options.getMainArm().getValue().toString()), true);
         }
 
         for (int i = 0; i < skinKeybinds.length; i++) {
@@ -48,7 +48,7 @@ public class SkinActions implements ActionType {
                 PlayerModelPart part = PlayerModelPart.values()[i];
                 boolean enabled = client.options.isPlayerModelPartEnabled(part);
                 client.options.togglePlayerModelPart(part, !enabled);
-                client.player.sendMessage(new LiteralText(part.getOptionName().getString() +" " + (enabled ? "enabled" : "disabled")), true);
+                client.player.sendMessage(Text.literal(part.getOptionName().getString() + " " + (enabled ? "enabled" : "disabled")), true);
             }
         }
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,8 +22,8 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.12.6",
+    "fabricloader": ">=0.14.21",
     "fabric": "*",
-    "minecraft": "1.18.*"
+    "minecraft": "1.20.*"
   }
 }


### PR DESCRIPTION
Based on changes from #1.

Fixes overflowing FOV values. When you increase it past the maximum (110) or minimum allowed FOV, until now it would reset back to 70. With this change the max or min value is clamped.